### PR TITLE
don't enable firewall by default

### DIFF
--- a/mail-server/networking.nix
+++ b/mail-server/networking.nix
@@ -20,7 +20,6 @@
   hostName = "${host_prefix}.${domain}";
 
   firewall = {
-    enable = true;
     allowedTCPPorts = [ 25 587 ]
       ++ (if enable_imap then [ 143 ] else [])
       ++ (if enable_pop3 then [ 110 ] else []);


### PR DESCRIPTION
It is default ON in NixOS and will conflict with `firewall.enable = false`, which some user may intentionally set.
In my opinion it is too high-level option to be set automatically.

Also, people who really don't want firewall, just do `lib.mkForce false` and won't even notice that this module requires it.