### PR TITLE
Added header filtering for removing sensitive information.

### DIFF
--- a/mail-server/postfix.nix
+++ b/mail-server/postfix.nix
@@ -47,7 +47,18 @@ let
   # every alias is owned (uniquely) by its user. We have to add the users own
   # address though
   vaccounts_file = builtins.toFile "vaccounts" (lib.concatStringsSep "\n" (vaccounts_identity ++ valiases_postfix));
+  
+  submissionHeaderCleanupRules = pkgs.writeText "submission_header_cleanup_rules" ''
+     ### Removes sensitive headers from mails handed in via the submission port.
+     ### See https://thomas-leister.de/mailserver-debian-stretch/
+     ### Uses "pcre" style regex.
 
+     /^Received:/            IGNORE
+     /^X-Originating-IP:/    IGNORE
+     /^X-Mailer:/            IGNORE
+     /^User-Agent:/          IGNORE
+     /^X-Enigmail:/          IGNORE
+  '';
 in
 {
   config = with cfg; lib.mkIf enable {
@@ -99,25 +110,11 @@ in
         smtpd_recipient_restrictions = "reject_non_fqdn_recipient,reject_unknown_recipient_domain,permit_sasl_authenticated,reject";
         cleanup_service_name = "submission-header-cleanup";
       };
-      
+
       extraMasterConf = ''
         submission-header-cleanup unix n - n    -       0       cleanup
-            -o header_checks=regexp:/etc/postfixsupport/submission_header_cleanup
+            -o header_checks=pcre:${submissionHeaderCleanupRules}
       '';
-    };
-    
-    environment.etc = {
-      "postfixsupport/submission_header_cleanup" = {
-        text = ''
-          ### Removes sensitive headers from mails handed in via the submission port.
-          ### Thanks to https://thomas-leister.de/mailserver-debian-stretch/
-
-          /^Received:/            IGNORE
-          /^X-Originating-IP:/    IGNORE
-          /^X-Mailer:/            IGNORE
-          /^User-Agent:/          IGNORE
-        '';
-      };
     };
   };
 }

--- a/mail-server/postfix.nix
+++ b/mail-server/postfix.nix
@@ -97,6 +97,26 @@ in
         smtpd_sender_login_maps = "hash:/etc/postfix/vaccounts";
         smtpd_sender_restrictions = "reject_sender_login_mismatch";
         smtpd_recipient_restrictions = "reject_non_fqdn_recipient,reject_unknown_recipient_domain,permit_sasl_authenticated,reject";
+        cleanup_service_name = "submission-header-cleanup";
+      };
+      
+      extraMasterConf = ''
+        submission-header-cleanup unix n - n    -       0       cleanup
+            -o header_checks=regexp:/etc/postfixsupport/submission_header_cleanup
+      '';
+    };
+    
+    environment.etc = {
+      "postfixsupport/submission_header_cleanup" = {
+        text = ''
+          ### Removes sensitive headers from mails handed in via the submission port.
+          ### Thanks to https://thomas-leister.de/mailserver-debian-stretch/
+
+          /^Received:/            IGNORE
+          /^X-Originating-IP:/    IGNORE
+          /^X-Mailer:/            IGNORE
+          /^User-Agent:/          IGNORE
+        '';
       };
     };
   };


### PR DESCRIPTION
This adds header filtering which essentially gets rid of the user's mail client's identification as well as the user's IP address etc.
I was not able to have the file placed in /etc/postfix, so I went for /etc/postfixsupport.