### PR TITLE
users.nix: ensure the group getting its gid set is vmailGroupName

### DIFF
--- a/mail-server/users.nix
+++ b/mail-server/users.nix
@@ -45,7 +45,7 @@ in
   config = lib.mkIf enable {
     # set the vmail gid to a specific value
     users.groups = {
-      vmail = { gid = vmailUIDStart; };
+      "${vmailGroupName}" = { gid = vmailUIDStart; };
     };
 
     # define all users


### PR DESCRIPTION
I'm concerned (but not completely sure) that this line sets the GID of the `vmail` group verbatim, and not necessarily the one configured by `vmailGroupName`.