### PR TITLE
Multi domain support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[Makefile]
+indent_style = tab
+indent_size = 8

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,3 @@ indent_style = space
 indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
-
-[Makefile]
-indent_style = tab
-indent_size = 8

--- a/default.nix
+++ b/default.nix
@@ -26,26 +26,17 @@ in
   options.mailserver = {
     enable = mkEnableOption "nixos-mailserver";
 
-    domain = mkOption {
+    fqdn = mkOption {
       type = types.str;
       example = "[ example.com ]";
-      description = "The primary domain that this mail server serves.";
+      description = "The fully qualified domain name of the mail server.";
     };
 
-    extraDomains = mkOption {
+    domains = mkOption {
       type = types.listOf types.str;
       example = "[ example.com ]";
       default = [];
-      description = "Extra domains that this mail server serves.";
-    };
-
-    hostPrefix = mkOption {
-      type = types.str;
-      default = "mail";
-      description = ''
-        The prefix of the FQDN of the server. In this example the FQDN of the server
-        is given by 'mail.example.com'
-      '';
+      description = "The domains that this mail server serves.";
     };
 
     loginAccounts = mkOption {

--- a/default.nix
+++ b/default.nix
@@ -28,8 +28,14 @@ in
 
     domain = mkOption {
       type = types.str;
-      example = "example.com";
-      description = "The domain that this mail server serves. So far only one domain is supported";
+      example = "[ example.com ]";
+      description = "The primary domain that this mail server serves.";
+    };
+
+    extraDomains = mkOption {
+      type = types.listOf types.str;
+      example = "[ example.com ]";
+      description = "Extra domains that this mail server serves.";
     };
 
     hostPrefix = mkOption {

--- a/default.nix
+++ b/default.nix
@@ -35,6 +35,7 @@ in
     extraDomains = mkOption {
       type = types.listOf types.str;
       example = "[ example.com ]";
+      default = [];
       description = "Extra domains that this mail server serves.";
     };
 

--- a/mail-server/common.nix
+++ b/mail-server/common.nix
@@ -14,10 +14,11 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program. If not, see <http://www.gnu.org/licenses/>
 
-{ config }:
+{ config, lib }:
 
 let
   cfg = config.mailserver;
+  inherit (lib.strings) stringToCharacters;
 in
 {
   # cert :: PATH
@@ -37,4 +38,10 @@ in
               else if cfg.certificateScheme == 3
                    then "/var/lib/acme/mailserver/key.pem"
                    else throw "Error: Certificate Scheme must be in { 1, 2, 3 }";
+
+  # appends cfg.domain to argument if it does not contain "@"
+  qualifyUser = user: (
+        if (builtins.any (c: c == "@") (stringToCharacters user))
+        then user
+        else "${user}@${cfg.domain}");
 }

--- a/mail-server/common.nix
+++ b/mail-server/common.nix
@@ -14,34 +14,27 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program. If not, see <http://www.gnu.org/licenses/>
 
-{ config, lib }:
+{ config }:
 
 let
   cfg = config.mailserver;
-  inherit (lib.strings) stringToCharacters;
 in
 {
   # cert :: PATH
   certificatePath = if cfg.certificateScheme == 1
              then cfg.certificateFile
              else if cfg.certificateScheme == 2
-                  then "${cfg.certificateDirectory}/cert-${cfg.domain}.pem"
+                  then "${cfg.certificateDirectory}/cert-${cfg.fqdn}.pem"
                   else if cfg.certificateScheme == 3
-                       then "/var/lib/acme/mailserver/fullchain.pem"
+                       then "/var/lib/acme/${cfg.fqdn}/fullchain.pem"
                        else throw "Error: Certificate Scheme must be in { 1, 2, 3 }";
 
   # key :: PATH
   keyPath = if cfg.certificateScheme == 1
         then cfg.keyFile
         else if cfg.certificateScheme == 2
-             then "${cfg.certificateDirectory}/key-${cfg.domain}.pem"
+             then "${cfg.certificateDirectory}/key-${cfg.fqdn}.pem"
               else if cfg.certificateScheme == 3
-                   then "/var/lib/acme/mailserver/key.pem"
+                   then "/var/lib/acme/${cfg.fqdn}/key.pem"
                    else throw "Error: Certificate Scheme must be in { 1, 2, 3 }";
-
-  # appends cfg.domain to argument if it does not contain "@"
-  qualifyUser = user: (
-        if (builtins.any (c: c == "@") (stringToCharacters user))
-        then user
-        else "${user}@${cfg.domain}");
 }

--- a/mail-server/common.nix
+++ b/mail-server/common.nix
@@ -26,7 +26,7 @@ in
              else if cfg.certificateScheme == 2
                   then "${cfg.certificateDirectory}/cert-${cfg.domain}.pem"
                   else if cfg.certificateScheme == 3
-                       then "/var/lib/acme/${cfg.hostPrefix}.${cfg.domain}/fullchain.pem"
+                       then "/var/lib/acme/mailserver/fullchain.pem"
                        else throw "Error: Certificate Scheme must be in { 1, 2, 3 }";
 
   # key :: PATH
@@ -35,6 +35,6 @@ in
         else if cfg.certificateScheme == 2
              then "${cfg.certificateDirectory}/key-${cfg.domain}.pem"
               else if cfg.certificateScheme == 3
-                   then "/var/lib/acme/${cfg.hostPrefix}.${cfg.domain}/key.pem"
+                   then "/var/lib/acme/mailserver/key.pem"
                    else throw "Error: Certificate Scheme must be in { 1, 2, 3 }";
 }

--- a/mail-server/dovecot.nix
+++ b/mail-server/dovecot.nix
@@ -16,7 +16,7 @@
 
 { config, pkgs, lib, ... }:
 
-with (import ./common.nix { inherit config lib; });
+with (import ./common.nix { inherit config; });
 
 let
   cfg = config.mailserver;

--- a/mail-server/dovecot.nix
+++ b/mail-server/dovecot.nix
@@ -16,7 +16,7 @@
 
 { config, pkgs, lib, ... }:
 
-with (import ./common.nix { inherit config; });
+with (import ./common.nix { inherit config lib; });
 
 let
   cfg = config.mailserver;

--- a/mail-server/nginx.nix
+++ b/mail-server/nginx.nix
@@ -46,6 +46,8 @@ in
       # @todo should we reload postfix here?
       postRun = ''
         systemctl reload nginx
+        systemctl reload postfix
+        systemctl reload dovecot2
       '';
     };
   };

--- a/mail-server/nginx.nix
+++ b/mail-server/nginx.nix
@@ -20,6 +20,7 @@
 with (import ./common.nix { inherit config; });
 
 let
+  inherit (lib.attrsets) genAttrs;
   cfg = config.mailserver;
   allDomains = [ cfg.domain ] ++ cfg.extraDomains;
   acmeRoot = "/var/lib/acme/acme-challenge";
@@ -38,7 +39,7 @@ in
            acmeRoot = acmeRoot;
        });
     };
-    security.acme.certs."${hostPrefix}.${domain}" = {
+    security.acme.certs."mailserver" = {
       # @todo what user/group should this run as?
       user = "postfix"; # cfg.user;
       group = "postfix"; # lib.mkDefault cfg.group;

--- a/mail-server/nginx.nix
+++ b/mail-server/nginx.nix
@@ -26,11 +26,11 @@ let
   acmeRoot = "/var/lib/acme/acme-challenge";
 in
 {
-  config = with cfg; lib.mkIf (certificateScheme == 3) {
+  config = lib.mkIf (cfg.certificateScheme == 3) {
     services.nginx = {
       enable = true;
-      virtualHosts = genAttrs allDomains (domain: {
-           serverName = "${hostPrefix}.${domain}";
+      virtualHosts = genAttrs (map (domain: "${cfg.hostPrefix}.${domain}") allDomains) (domain: {
+           serverName = "${domain}";
            forceSSL = true;
            enableACME = true;
            locations."/" = {
@@ -40,11 +40,8 @@ in
        });
     };
     security.acme.certs."mailserver" = {
-      # @todo what user/group should this run as?
-      user = "postfix"; # cfg.user;
-      group = "postfix"; # lib.mkDefault cfg.group;
-      domain = "${hostPrefix}.${domain}";
-      extraDomains = map (domain: "${hostPrefix}.${domain}") extraDomains;
+      domain = "${cfg.hostPrefix}.${cfg.domain}";
+      extraDomains = genAttrs (map (domain: "${cfg.hostPrefix}.${domain}") cfg.extraDomains) (domain: null);
       webroot = acmeRoot;
       # @todo should we reload postfix here?
       postRun = ''

--- a/mail-server/postfix.nix
+++ b/mail-server/postfix.nix
@@ -16,7 +16,7 @@
 
 { config, pkgs, lib, ... }:
 
-with (import ./common.nix { inherit config; });
+with (import ./common.nix { inherit config lib; });
 
 let
   inherit (lib.strings) concatStringsSep;
@@ -27,11 +27,11 @@ let
   valiases_postfix = map
     (from:
       let to = cfg.virtualAliases.${from};
-      in "${from} ${to}")
+      in "${qualifyUser from} ${qualifyUser to}")
     (builtins.attrNames cfg.virtualAliases);
 
   # accountToIdentity :: User -> String
-  accountToIdentity = account: "${account.name} ${account.name}";
+  accountToIdentity = account: "${qualifyUser account.name} ${qualifyUser account.name}";
 
   # vaccounts_identity :: [ String ]
   vaccounts_identity = map accountToIdentity (lib.attrValues cfg.loginAccounts);

--- a/mail-server/postfix.nix
+++ b/mail-server/postfix.nix
@@ -19,17 +19,19 @@
 with (import ./common.nix { inherit config; });
 
 let
+  inherit (lib.strings) concatStringsSep;
   cfg = config.mailserver;
+  allDomains = [ cfg.domain ] ++ cfg.extraDomains;
 
   # valiases_postfix :: [ String ]
   valiases_postfix = map
     (from:
       let to = cfg.virtualAliases.${from};
-      in "${from}@${cfg.domain} ${to}@${cfg.domain}")
+      in "${from} ${to}")
     (builtins.attrNames cfg.virtualAliases);
 
   # accountToIdentity :: User -> String
-  accountToIdentity = account: "${account.name}@${cfg.domain} ${account.name}@${cfg.domain}";
+  accountToIdentity = account: "${account.name} ${account.name}";
 
   # vaccounts_identity :: [ String ]
   vaccounts_identity = map accountToIdentity (lib.attrValues cfg.loginAccounts);
@@ -38,7 +40,7 @@ let
   valiases_file = builtins.toFile "valias" (lib.concatStringsSep "\n" valiases_postfix);
 
   # vhosts_file :: Path
-  vhosts_file = builtins.toFile "vhosts" cfg.domain;
+  vhosts_file = builtins.toFile "vhosts" (concatStringsSep ", " allDomains);
 
   # vaccounts_file :: Path
   # see
@@ -47,7 +49,7 @@ let
   # every alias is owned (uniquely) by its user. We have to add the users own
   # address though
   vaccounts_file = builtins.toFile "vaccounts" (lib.concatStringsSep "\n" (vaccounts_identity ++ valiases_postfix));
-  
+
   submissionHeaderCleanupRules = pkgs.writeText "submission_header_cleanup_rules" ''
      # Removes sensitive headers from mails handed in via the submission port.
      # See https://thomas-leister.de/mailserver-debian-stretch/
@@ -67,12 +69,12 @@ in
       enable = true;
       networksStyle = "host";
       mapFiles."valias" = valiases_file;
-      mapFiles."vaccounts" = vaccounts_file; 
+      mapFiles."vaccounts" = vaccounts_file;
       sslCert = certificatePath;
       sslKey = keyPath;
       enableSubmission = true;
 
-      extraConfig = 
+      extraConfig =
       ''
         # Extra Config
 
@@ -116,7 +118,7 @@ in
       '';
 
       submissionOptions =
-      { 
+      {
         smtpd_tls_security_level = "encrypt";
         smtpd_sasl_auth_enable = "yes";
         smtpd_sasl_type = "dovecot";

--- a/mail-server/postfix.nix
+++ b/mail-server/postfix.nix
@@ -16,22 +16,21 @@
 
 { config, pkgs, lib, ... }:
 
-with (import ./common.nix { inherit config lib; });
+with (import ./common.nix { inherit config; });
 
 let
   inherit (lib.strings) concatStringsSep;
   cfg = config.mailserver;
-  allDomains = [ cfg.domain ] ++ cfg.extraDomains;
 
   # valiases_postfix :: [ String ]
   valiases_postfix = map
     (from:
       let to = cfg.virtualAliases.${from};
-      in "${qualifyUser from} ${qualifyUser to}")
+      in "${from} ${to}")
     (builtins.attrNames cfg.virtualAliases);
 
   # accountToIdentity :: User -> String
-  accountToIdentity = account: "${qualifyUser account.name} ${qualifyUser account.name}";
+  accountToIdentity = account: "${account.name} ${account.name}";
 
   # vaccounts_identity :: [ String ]
   vaccounts_identity = map accountToIdentity (lib.attrValues cfg.loginAccounts);
@@ -40,7 +39,7 @@ let
   valiases_file = builtins.toFile "valias" (lib.concatStringsSep "\n" valiases_postfix);
 
   # vhosts_file :: Path
-  vhosts_file = builtins.toFile "vhosts" (concatStringsSep ", " allDomains);
+  vhosts_file = builtins.toFile "vhosts" (concatStringsSep "\n" cfg.domains);
 
   # vaccounts_file :: Path
   # see

--- a/mail-server/services.nix
+++ b/mail-server/services.nix
@@ -24,14 +24,14 @@ let
   cert = if cfg.certificateScheme == 1
          then cfg.certificateFile
          else if cfg.certificateScheme == 2
-              then "${cfg.certificateDirectory}/cert-${cfg.domain}.pem"
+              then "${cfg.certificateDirectory}/cert-${cfg.fqdn.pem"
               else "";
 
   # key :: PATH
   key = if cfg.certificateScheme == 1
         then cfg.keyFile
         else if cfg.certificateScheme == 2
-             then "${cfg.certificateDirectory}/key-${cfg.domain}.pem"
+             then "${cfg.certificateDirectory}/key-${cfg.fqdn}.pem"
              else "";
 in
 {

--- a/mail-server/systemd.nix
+++ b/mail-server/systemd.nix
@@ -64,7 +64,7 @@ in
     # Create certificates and maildir folder
     systemd.services.postfix = {
       after = (if (certificateScheme == 3) then [ "nginx.service" ] else []);
-      preStart = 
+      preStart =
       ''
       # Create mail directory and set permissions. See
       # <http://wiki2.dovecot.org/SharedMailboxes/Permissions>.

--- a/mail-server/systemd.nix
+++ b/mail-server/systemd.nix
@@ -23,10 +23,10 @@ let
         ''
           # Create certificates if they do not exist yet
           dir="${cfg.certificateDirectory}"
-          fqdn="${cfg.hostPrefix}.${cfg.domain}"
+          fqdn="${cfg.fqdn}"
           case $fqdn in /*) fqdn=$(cat "$fqdn");; esac
-          key="''${dir}/key-${cfg.domain}.pem";
-          cert="''${dir}/cert-${cfg.domain}.pem";
+          key="''${dir}/key-${cfg.fqdn}.pem";
+          cert="''${dir}/cert-${cfg.fqdn}.pem";
 
           if [ ! -f "''${key}" ] || [ ! -f "''${cert}" ]
           then
@@ -50,7 +50,7 @@ let
           then
 
               ${pkgs.opendkim}/bin/opendkim-genkey -s "${cfg.dkimSelector}" \
-                                                   -d ${cfg.domain} \
+                                                   -d ${cfg.fqdn} \
                                                    --directory="${cfg.dkimKeyDirectory}"
               chown rmilter:rmilter "${dkim_key}"
           fi

--- a/mail-server/users.nix
+++ b/mail-server/users.nix
@@ -19,6 +19,8 @@
 with config.mailserver;
 
 let
+  qualifyUser = (import ./common.nix { inherit config lib; }).qualifyUser;
+
   vmail_user = {
     name = vmailUserName;
     isNormalUser = false;
@@ -30,14 +32,14 @@ let
 
   # accountsToUser :: String -> UserRecord
   accountsToUser = account: {
-    name = account.name;
+    name = (qualifyUser account.name);
     isNormalUser = false;
     group = vmailGroupName;
     inherit (account) hashedPassword;
   };
 
   # mail_users :: { [String]: UserRecord }
-  mail_users = lib.foldl (prev: next: prev // { "${next.name}" = next; }) {}
+  mail_users = lib.foldl (prev: next: prev // { "${qualifyUser next.name}" = next; }) {}
     (map accountsToUser (lib.attrValues loginAccounts));
 
 in

--- a/mail-server/users.nix
+++ b/mail-server/users.nix
@@ -30,7 +30,7 @@ let
 
   # accountsToUser :: String -> UserRecord
   accountsToUser = account: {
-    name = account.name + "@" + domain;
+    name = account.name;
     isNormalUser = false;
     group = vmailGroupName;
     inherit (account) hashedPassword;

--- a/mail-server/users.nix
+++ b/mail-server/users.nix
@@ -19,8 +19,6 @@
 with config.mailserver;
 
 let
-  qualifyUser = (import ./common.nix { inherit config lib; }).qualifyUser;
-
   vmail_user = {
     name = vmailUserName;
     isNormalUser = false;
@@ -32,14 +30,14 @@ let
 
   # accountsToUser :: String -> UserRecord
   accountsToUser = account: {
-    name = (qualifyUser account.name);
+    name = account.name;
     isNormalUser = false;
     group = vmailGroupName;
     inherit (account) hashedPassword;
   };
 
   # mail_users :: { [String]: UserRecord }
-  mail_users = lib.foldl (prev: next: prev // { "${qualifyUser next.name}" = next; }) {}
+  mail_users = lib.foldl (prev: next: prev // { "${next.name}" = next; }) {}
     (map accountsToUser (lib.attrValues loginAccounts));
 
 in

--- a/nixops/single-server.nix
+++ b/nixops/single-server.nix
@@ -10,23 +10,21 @@
 
         mailserver = {
           enable = true;
-          domain = "example.com";
-          extraDomains = [ "example2.com" ];
-
-          hostPrefix = "mail";
+          fqdn = "mail.example.com";
+          domains = [ "example.com", "example2.com" ];
           loginAccounts = {
-              "user1" = {
+              "user1@example.com" = {
                   hashedPassword = "$6$/z4n8AQl6K$kiOkBTWlZfBd7PvF5GsJ8PmPgdZsFGN1jPGZufxxr60PoR0oUsrvzm2oQiflyz5ir9fFJ.d/zKm/NgLXNUsNX/";
               };
           };
           virtualAliases = {
-              "info" = "user1";
-              "postmaster" = "user1";
-              "abuse" = "user1";
-              "user1@example2.com" = "user1";
-              "info@example2.com" = "user1";
-              "postmaster@example2.com" = "user1";
-              "abuse@example2.com" = "user1";
+              "info@example.com" = "user1@example.com";
+              "postmaster@example.com" = "user1@example.com";
+              "abuse@example.com" = "user1@example.com";
+              "user1@example2.com" = "user1@example.com";
+              "info@example2.com" = "user1@example.com";
+              "postmaster@example2.com" = "user1@example.com";
+              "abuse@example2.com" = "user1@example.com";
           };
         };
     };

--- a/nixops/single-server.nix
+++ b/nixops/single-server.nix
@@ -11,7 +11,7 @@
         mailserver = {
           enable = true;
           fqdn = "mail.example.com";
-          domains = [ "example.com", "example2.com" ];
+          domains = [ "example.com" "example2.com" ];
           loginAccounts = {
               "user1@example.com" = {
                   hashedPassword = "$6$/z4n8AQl6K$kiOkBTWlZfBd7PvF5GsJ8PmPgdZsFGN1jPGZufxxr60PoR0oUsrvzm2oQiflyz5ir9fFJ.d/zKm/NgLXNUsNX/";

--- a/nixops/single-server.nix
+++ b/nixops/single-server.nix
@@ -11,17 +11,22 @@
         mailserver = {
           enable = true;
           domain = "example.com";
+          extraDomains = [ "example2.com" ];
 
           hostPrefix = "mail";
           loginAccounts = {
-              user1 = {
+              "user1@example.com" = {
                   hashedPassword = "$6$/z4n8AQl6K$kiOkBTWlZfBd7PvF5GsJ8PmPgdZsFGN1jPGZufxxr60PoR0oUsrvzm2oQiflyz5ir9fFJ.d/zKm/NgLXNUsNX/";
               };
           };
           virtualAliases = {
-              info = "user1";
-              postmaster = "user1";
-              abuse = "user1";
+              "user1@example2.com" = "user1@example.com";
+              "info@example.com" = "user1@example.com";
+              "postmaster@example.com" = "user1@example.com";
+              "abuse@example.com" = "user1@example.com";
+              "info@example2.com" = "user1@example.com";
+              "postmaster@example2.com" = "user1@example.com";
+              "abuse@example2.com" = "user1@example.com";
           };
         };
     };

--- a/nixops/single-server.nix
+++ b/nixops/single-server.nix
@@ -15,18 +15,18 @@
 
           hostPrefix = "mail";
           loginAccounts = {
-              "user1@example.com" = {
+              "user1" = {
                   hashedPassword = "$6$/z4n8AQl6K$kiOkBTWlZfBd7PvF5GsJ8PmPgdZsFGN1jPGZufxxr60PoR0oUsrvzm2oQiflyz5ir9fFJ.d/zKm/NgLXNUsNX/";
               };
           };
           virtualAliases = {
-              "user1@example2.com" = "user1@example.com";
-              "info@example.com" = "user1@example.com";
-              "postmaster@example.com" = "user1@example.com";
-              "abuse@example.com" = "user1@example.com";
-              "info@example2.com" = "user1@example.com";
-              "postmaster@example2.com" = "user1@example.com";
-              "abuse@example2.com" = "user1@example.com";
+              "info" = "user1";
+              "postmaster" = "user1";
+              "abuse" = "user1";
+              "user1@example2.com" = "user1";
+              "info@example2.com" = "user1";
+              "postmaster@example2.com" = "user1";
+              "abuse@example2.com" = "user1";
           };
         };
     };

--- a/tests/extern.nix
+++ b/tests/extern.nix
@@ -25,14 +25,14 @@ import <nixpkgs/nixos/tests/make-test.nix> {
 
             mailserver = {
               enable = true;
-              domain = "example.com";
+              fqdn = "mail.example.com";
+              domains = [ "example.com" ];
 
-              hostPrefix = "mail";
               loginAccounts = {
-                  user1 = {
+                  "user1@example.com" = {
                       hashedPassword = "$6$/z4n8AQl6K$kiOkBTWlZfBd7PvF5GsJ8PmPgdZsFGN1jPGZufxxr60PoR0oUsrvzm2oQiflyz5ir9fFJ.d/zKm/NgLXNUsNX/";
                   };
-                  user2 = {
+                  "user2@example.com" = {
                       hashedPassword = "$6$u61JrAtuI0a$nGEEfTP5.eefxoScUGVG/Tl0alqla2aGax4oTd85v3j3xSmhv/02gNfSemv/aaMinlv9j/ZABosVKBrRvN5Qv0";
                   };
               };

--- a/tests/intern.nix
+++ b/tests/intern.nix
@@ -25,11 +25,11 @@ import <nixpkgs/nixos/tests/make-test.nix> {
 
         mailserver = {
           enable = true;
-          domain = "example.com";
+          fqdn = "mail.example.com";
+          domains = [ "example.com" ];
 
-          hostPrefix = "mail";
           loginAccounts = {
-              user1 = {
+              "user1@example.com" = {
                   hashedPassword = "$6$/z4n8AQl6K$kiOkBTWlZfBd7PvF5GsJ8PmPgdZsFGN1jPGZufxxr60PoR0oUsrvzm2oQiflyz5ir9fFJ.d/zKm/NgLXNUsNX/";
               };
           };


### PR DESCRIPTION
This is super preliminary, just wanted to get the code in a place where it can be reviewed. Some notes:

* I opted to go with `cfg.domain` and `cfg.extraDomains` over `cfg.domains` - it simplified the logic in a few places. Notably, in my current implementation, self-signed certs do not support extraDomains.
* ACME supports all domains using a single certificate - as far as I can tell postfix doesn't have an option to use multiple certs. The certificate is placed in `/var/lib/acme/mailserver/` instead of in any domain subfolder. Certs are also issued independently for each domain and placed in the corresponding domain folder. This is so I don't have to re-implement the nginx ACME configurations.
* I changed the domain that the certs were issued to via ACME due to a conflict with my personal webserver. Only `mail.example.com`, not `example.com` will have an nginx virtualhost set up and certs issued.
* Usernames without a domain will have `@${cfg.domain}` appended to them - another reason I chose `cfg.extraDomains` 
* I added a `.editorconfig` (NixIDEA was having trouble with the indentation) let me know if you want me to remove it.

I've only done minimal testing so far, but it appears to be working on my mail server.
