### PR TITLE
README.md: suggest using ~all instead of -all

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ need to
 
 | Name (Subdomain) | TTL   | Type | Priority | Value                             |
 | ---------------- | ----- | ---- | -------- | -----------------                 |
-| domain1.com      | 10800 | TXT  |          | `v=spf1 ip4:xxx.xxx.xxx.xxx -all` |
+| domain1.com      | 10800 | TXT  |          | `v=spf1 ip4:xxx.xxx.xxx.xxx ~all` |
 
 ### DKIM signature
 


### PR DESCRIPTION
If you use an SPF record like `v=spf1 ip4:xxx.xxx.xxx.xxx -all` mail-tester will deduct 2 points, saying

> You have **?all** in your SPF, instead of **~all**.  This means we can't verify if your SPF is good, although it might probably be!

This may be a bug with mail-tester, but according to this it is generally harmless to use `~all`: https://wordtothewise.com/2014/06/authenticating-spf/

Note that I don't really know much about what is the best practice here. @r-raymond is there a particular reason you went with `-all`?