### PR TITLE
Add debug option for verbose logging

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -256,6 +256,16 @@ in
 
       '';
     };
+
+    debug = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to enable verbose logging for mailserver related services.  This
+        intended be used for development purposes only, you probably don't want
+        to enable this unless you're hacking on nixos-mailserver.
+      '';
+    };
   };
 
   imports = [

--- a/mail-server/dovecot.nix
+++ b/mail-server/dovecot.nix
@@ -53,7 +53,12 @@ in
 
       extraConfig = ''
         #Extra Config
-        #mail_debug = yes
+        ${lib.optionalString debug ''
+          mail_debug = yes
+          auth_debug = yes
+          verbose_ssl = yes
+        ''}
+
         mail_access_groups = ${vmailGroupName}
         ssl = required
 

--- a/mail-server/rmilter.nix
+++ b/mail-server/rmilter.nix
@@ -51,8 +51,8 @@ in
     };
 
     services.rmilter = {
+      inherit debug;
       enable = true;
-      #debug = true;
       postfix.enable = true;
       rspamd = {
         enable = true;


### PR DESCRIPTION
This only does stuff to the dovecot service for now, but I thought it might be useful to have one option that enables verbose logging for the various services that nixos-mailserver uses.

There's actually another dovecot option that I find useful while setting up a mailserver for the first time, `    auth_debug_passwords = yes` but I have deliberately excluded that because it's kind of unsafe.  If someone really wants that it' possible to add it to `services.dovecot2.extraConfig`.