### PR TITLE
mail-server/dovecot.nix: remove trailing slash from dovecot_maildir

### DIFF
--- a/mail-server/dovecot.nix
+++ b/mail-server/dovecot.nix
@@ -21,8 +21,8 @@ with (import ./common.nix { inherit config; });
 let
   cfg = config.mailserver;
 
-  # maildir in format "/${domain}/${user}/"
-  dovecot_maildir = "maildir:${cfg.mailDirectory}/%d/%n/";
+  # maildir in format "/${domain}/${user}"
+  dovecot_maildir = "maildir:${cfg.mailDirectory}/%d/%n";
 
 in
 {


### PR DESCRIPTION
This is probably harmless, but before this change I was seeing this in my logs (note the `//`):

```
Debug: Namespace inbox: type=private, prefix=, sep=/, inbox=yes, hidden=no, list=yes, subscriptions=yes location=maildir:/mnt/home/vmail//ruben/
Debug: maildir++: root=/mnt/home/vmail//ruben, index=, indexpvt=, control=, inbox=/mnt/home/vmail//ruben, alt=
```