### PR TITLE
mail-server/postfix.nix: set mydestination to localhost

### DIFF
--- a/mail-server/postfix.nix
+++ b/mail-server/postfix.nix
@@ -76,6 +76,7 @@ in
       extraConfig =
       ''
         # Extra Config
+        mydestination = localhost
 
         smtpd_banner = ${fqdn} ESMTP NO UCE
         disable_vrfy_command = yes


### PR DESCRIPTION
In the event that your `cfg.fqdn` is the same as a domain in `cfg.domains`, you will not be able to receive mail for users like `user1@fqdn` because postfix will try to deliver the mail using the local transport (to system users) rather than the virtual transport (through dovecot).

This is because the default value of mydestination is this:

```
# postconf | grep mydestination                                                     
mydestination = $myhostname, localhost.$mydomain, localhost
```

Which means that postfix will use the local transport (bypassing dovecot) for `$myhostname`.  Ref: https://serverfault.com/a/608616

I have a case of this in my logs using the following configuration:

```
mailserver = {
  enable = true;
  fqdn = "maher.fyi";
  domains = [ "maher.fyi" "rkm.id.au" ];
  vmailUserName = "vmail";
  vmailGroupName = "vmail";
  certificateScheme = 3;
  loginAccounts = {
    "ruben@maher.fyi".hashedPassword = "REDACTED";
    "nadiah@maher.fyi".hashedPassword = "REDACTED";
  };
  dkimKeyDirectory = "/var/dkim";
  mailDirectory = "/mnt/home/${config.users.users.vmail.name}";
  virtualAliases = {
    "*" = "ruben@maher.fyi";
  };
  enableImap = true;
  enableImapSsl = true;
};
```

Now I'm trying to send an email to `nadiah@maher.fyi` from `ruben@maher.fyi` (note `relay=local` and `status=bounced`).

```
Nov 13 20:41:49 maher.fyi postfix/local[6293]: EA801DE1C53: to=<ruben@maher.fyi>, relay=local, delay=0.26, delays=0.21/0.02/0/0.02, dsn=5.1.1, status=bounced (unknown user: "ruben")                              
Nov 13 20:41:49 maher.fyi postfix/cleanup[6295]: 28198DE1C54: message-id=<20171113101149.28198DE1C54@maher.fyi>                                                                                                    
Nov 13 20:41:49 maher.fyi postfix/bounce[6294]: EA801DE1C53: sender non-delivery notification: 28198DE1C54                                                                                                         
Nov 13 20:41:49 maher.fyi postfix/qmgr[4896]: 28198DE1C54: from=<>, size=2496, nrcpt=1 (queue active)                                                                                                              
Nov 13 20:41:49 maher.fyi postfix/qmgr[4896]: EA801DE1C53: removed                                                                                                                                                 
Nov 13 20:41:49 maher.fyi postfix/local[6293]: 28198DE1C54: to=<nadiah@maher.fyi>, relay=local, delay=0.03, delays=0.02/0/0/0.01, dsn=5.1.1, status=bounced (unknown user: "nadiah")                               
Nov 13 20:41:49 maher.fyi postfix/qmgr[4896]: 28198DE1C54: removed 
```

This makes sense if you look at this message on the postfix mailling list: http://postfix.1071664.n5.nabble.com/email-address-user-domain-tld-as-username-tp61766p61773.html

> The local(8) delivery agent requires system account names without @.

> The virtual(8) delivery agent requires user@domain account names.

Postfix is trying to deliver using the local transport to an account name that includes `@domain`, so it bounces.

The most concerning part about this is that before this commit, users who have `cfg.fqdn` the same as a domain in `cfg.domains` will not have a working mailserver after following the instructions in the readme for creating login accounts!

This commit also resolves the following warning I was seeing in the logs, which is what tipped me off to this in the first place (aside from issues receiving mail):

```
Nov 14 09:03:42 maher.fyi postfix/trivial-rewrite[5502]: warning: do not list domain maher.fyi in BOTH mydestination and virtual_mailbox_domains
```

This fixes the problem for me.  I don't know if I've explained this very well, please let me know if you'd like me to give more details.