### PR TITLE
Per user sieve scripts

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -59,6 +59,29 @@ in
               ```
             '';
           };
+
+          sieveScript = mkOption {
+            type = with types; nullOr lines;
+            default = null;
+            example = ''
+              require ["fileinto", "mailbox"];
+
+              if address :is "from" "notifications@github.com" {
+                fileinto :create "GitHub";
+                stop;
+              }
+
+              # This must be the last rule, it will check if list-id is set, and
+              # file the message into the Lists folder for further investigation
+              elsif header :matches "list-id" "<?*>" {
+                fileinto :create "Lists";
+                stop;
+              }
+            '';
+            description = ''
+              Per-user sieve script.
+            '';
+          };
         };
 
         config.name = mkDefault name;

--- a/mail-server/dovecot.nix
+++ b/mail-server/dovecot.nix
@@ -107,6 +107,10 @@ in
             special_use = \Sent
           }
         }
+
+        plugin {
+          sieve = file:/var/sieve/%u.sieve
+        }
       '';
     };
   };


### PR DESCRIPTION
This is my proposed solution to #36.

It was a seamless change for me, but I'd recommend backing up your maildirs before trying it.  The biggest change is making `loginAccounts` not system users.

So also beware if you're using `loginAccounts` as actual users (but I very much doubt that because their home dirs were previously set to `/var/empty`.

You'll end up with two new files for each domain: `${mailDirectory}/domain/passwd` and `${mailDirectory}/domain/shadow`.

Here's a relevant snippet from the logs showing the sieve script getting used:

```
Nov 18 15:27:17 maher.fyi dovecot[24424]: lmtp(ruben@maher.fyi): Debug: sieve: Pigeonhole version 0.4.20 (7cd71ba) initializing
Nov 18 15:27:17 maher.fyi dovecot[24424]: lmtp(ruben@maher.fyi): Debug: sieve: include: sieve_global is not set; it is currently not possible to include `:global' scripts.
Nov 18 15:27:17 maher.fyi dovecot[24424]: lmtp(ruben@maher.fyi): Debug: qMerNK29D1p0DQAAzVmk8w: sieve: file storage: Performing auto-detection
Nov 18 15:27:17 maher.fyi dovecot[24424]: lmtp(ruben@maher.fyi): Debug: qMerNK29D1p0DQAAzVmk8w: sieve: file storage: Root exists (/mnt/home/vmail/maher.fyi/ruben)
Nov 18 15:27:17 maher.fyi dovecot[24424]: lmtp(ruben@maher.fyi): Debug: qMerNK29D1p0DQAAzVmk8w: sieve: file storage: Storage path `/mnt/home/vmail/maher.fyi/ruben/sieve' not found
Nov 18 15:27:17 maher.fyi dovecot[24424]: lmtp(ruben@maher.fyi): Debug: qMerNK29D1p0DQAAzVmk8w: sieve: file storage: Active script path is unconfigured; using default (path=~/.dovecot.sieve)
Nov 18 15:27:17 maher.fyi dovecot[24424]: lmtp(ruben@maher.fyi): Debug: qMerNK29D1p0DQAAzVmk8w: sieve: file storage: Using Sieve script path: /mnt/home/vmail/maher.fyi/ruben/.dovecot.sieve
Nov 18 15:27:17 maher.fyi dovecot[24424]: lmtp(ruben@maher.fyi): Debug: qMerNK29D1p0DQAAzVmk8w: sieve: file script: Opened script `.dovecot' from `/mnt/home/vmail/maher.fyi/ruben/.dovecot.sieve'
Nov 18 15:27:17 maher.fyi dovecot[24424]: lmtp(ruben@maher.fyi): Debug: qMerNK29D1p0DQAAzVmk8w: sieve: file storage: Using Sieve script path: /var/lib/dovecot/sieve/before
Nov 18 15:27:17 maher.fyi dovecot[24424]: lmtp(ruben@maher.fyi): Debug: qMerNK29D1p0DQAAzVmk8w: sieve: file script: Opened script `before' from `/var/lib/dovecot/sieve/before'
Nov 18 15:27:17 maher.fyi dovecot[24424]: lmtp(ruben@maher.fyi): Debug: qMerNK29D1p0DQAAzVmk8w: sieve: Executed before user's personal Sieve script(1): /var/lib/dovecot/sieve/before
Nov 18 15:27:17 maher.fyi dovecot[24424]: lmtp(ruben@maher.fyi): Debug: qMerNK29D1p0DQAAzVmk8w: sieve: Using the following location for user's Sieve script: /mnt/home/vmail/maher.fyi/ruben/.dovecot.sieve
Nov 18 15:27:17 maher.fyi dovecot[24424]: lmtp(ruben@maher.fyi): Debug: Mailbox <lmtp DATA>: Opened mail UID=1 because: header Message-ID (Cache file is unusable)
Nov 18 15:27:17 maher.fyi dovecot[24424]: lmtp(ruben@maher.fyi): Debug: qMerNK29D1p0DQAAzVmk8w: sieve: Opening script 1 of 2 from `/var/lib/dovecot/sieve/before'
Nov 18 15:27:17 maher.fyi dovecot[24424]: lmtp(ruben@maher.fyi): Debug: qMerNK29D1p0DQAAzVmk8w: sieve: Loading script /var/lib/dovecot/sieve/before
Nov 18 15:27:17 maher.fyi dovecot[24424]: lmtp(ruben@maher.fyi): Debug: qMerNK29D1p0DQAAzVmk8w: sieve: Script binary /var/lib/dovecot/sieve/before.svbin successfully loaded
Nov 18 15:27:17 maher.fyi dovecot[24424]: lmtp(ruben@maher.fyi): Debug: qMerNK29D1p0DQAAzVmk8w: sieve: binary save: not saving binary /var/lib/dovecot/sieve/before.svbin, because it is already stored
Nov 18 15:27:17 maher.fyi dovecot[24424]: lmtp(ruben@maher.fyi): Debug: qMerNK29D1p0DQAAzVmk8w: sieve: Executing script from `/var/lib/dovecot/sieve/before.svbin'
Nov 18 15:27:17 maher.fyi dovecot[24424]: lmtp(ruben@maher.fyi): Debug: Mailbox <lmtp DATA>: Opened mail UID=1 because: header X-Spam (Cache file is unusable)
Nov 18 15:27:17 maher.fyi dovecot[24424]: lmtp(ruben@maher.fyi): Debug: qMerNK29D1p0DQAAzVmk8w: sieve: Opening script 2 of 2 from `/mnt/home/vmail/maher.fyi/ruben/.dovecot.sieve'
Nov 18 15:27:17 maher.fyi dovecot[24424]: lmtp(ruben@maher.fyi): Debug: qMerNK29D1p0DQAAzVmk8w: sieve: Loading script /mnt/home/vmail/maher.fyi/ruben/.dovecot.sieve
Nov 18 15:27:17 maher.fyi dovecot[24424]: lmtp(ruben@maher.fyi): Debug: qMerNK29D1p0DQAAzVmk8w: sieve: Script `.dovecot' from /mnt/home/vmail/maher.fyi/ruben/.dovecot.sieve successfully compiled
Nov 18 15:27:17 maher.fyi dovecot[24424]: lmtp(ruben@maher.fyi): Debug: qMerNK29D1p0DQAAzVmk8w: sieve: Executing script from `/mnt/home/vmail/maher.fyi/ruben/.dovecot.sieve'
```