### PR TITLE
s/vmailUIDStart/vmailUID/g

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -100,12 +100,13 @@ in
       default = {};
     };
 
-    vmailUIDStart = mkOption {
+    vmailUID = mkOption {
       type = types.int;
       default = 5000;
       description = ''
-        The unix UID where the loginAccounts are created. 5000 means that the first
-        user will get 5000, the second 5001, ...
+        The unix UID of the virtual mail user.  Be mindful that if this is
+        changed, you will need to manually adjust the permissions of
+        mailDirectory.
       '';
     };
 

--- a/mail-server/users.nix
+++ b/mail-server/users.nix
@@ -22,7 +22,7 @@ let
   vmail_user = {
     name = vmailUserName;
     isNormalUser = false;
-    uid = vmailUIDStart;
+    uid = vmailUID;
     home = mailDirectory;
     createHome = true;
     group = vmailGroupName;
@@ -46,7 +46,7 @@ in
   config = lib.mkIf enable {
     # set the vmail gid to a specific value
     users.groups = {
-      "${vmailGroupName}" = { gid = vmailUIDStart; };
+      "${vmailGroupName}" = { gid = vmailUID; };
     };
 
     # define all users

--- a/tests/intern.nix
+++ b/tests/intern.nix
@@ -35,7 +35,7 @@ import <nixpkgs/nixos/tests/make-test.nix> {
           };
 
           vmailGroupName = "vmail";
-          vmailUIDStart = 5000;
+          vmailUID = 5000;
         };
     };
 


### PR DESCRIPTION
The name vmailUIDStart is not consistent with how it is being used (as the UID of the virtual mail user).

@r-raymond this is a follow up from your review of #37 the other day.