### PR TITLE
mail-server/dovecot.nix: automatically subscribe to new mailboxes

### DIFF
--- a/mail-server/dovecot.nix
+++ b/mail-server/dovecot.nix
@@ -111,6 +111,9 @@ in
         plugin {
           sieve = file:/var/sieve/%u.sieve
         }
+
+        lda_mailbox_autosubscribe = yes
+        lda_mailbox_autocreate = yes
       '';
     };
   };


### PR DESCRIPTION
When a mailbox is created by sieve or is delivered to directly by IMAP commands, created IMAP folders are not subscribed to by dovecot.  These configuration options change that.

Before:

```
$ doveconf | grep -e '^lda'                                                                                       
lda_mailbox_autocreate = no
lda_mailbox_autosubscribe = no
lda_original_recipient_header =
```

After: 
```
$ doveconf | grep -e '^lda'
lda_mailbox_autocreate = yes
lda_mailbox_autosubscribe = yes
lda_original_recipient_header =
```

Despite being prefixed with `lda` (local delivery agent) and the fact that we are using `lmtp` for virtual users, I believe this has an effect because:

- it worked for me (subscribed to mailbox 'GitHub' like in the sieve example)
- I see this line in the logs:
`Nov 21 08:36:25 maher.fyi dovecot[15936]: lmtp(ruben@maher.fyi): Debug: GitHub: Mailbox opened because: lib-lda delivery`
