### PR TITLE
catchAll for undefined loginAccounts only

### DIFF
--- a/mail-server/postfix.nix
+++ b/mail-server/postfix.nix
@@ -26,7 +26,7 @@ let
   valiases_postfix = lib.flatten (lib.mapAttrsToList
     (name: value:
       let to = name;
-          in map (from: "${from} ${to}") value.aliases)
+          in map (from: "${from} ${to}") (value.aliases ++ lib.singleton name))
     cfg.loginAccounts);
 
   # catchAllPostfix :: [ String ]


### PR DESCRIPTION
Tests and fixes (I think) the behaviour described here: https://github.com/r-raymond/nixos-mailserver/issues/49#issuecomment-352910371