### PR TITLE
Dovecot: Mailbox config + hierarchy separator.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -201,6 +201,64 @@ in
       '';
     };
 
+    useFsLayout = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Sets whether dovecot should organize mail in subdirectories:
+
+        - /var/vmail/example.com/user/.folder.subfolder/ (default layout)
+        - /var/vmail/example.com/user/folder/subfolder/  (FS layout)
+
+        See https://wiki2.dovecot.org/MailboxFormat/Maildir for details.
+      '';
+    };
+
+    hierarchySeparator = mkOption {
+      type = types.string;
+      default = ".";
+      description = ''
+        The hierarchy separator for mailboxes used by dovecot for the namespace 'inbox'.
+        Dovecot defaults to "." but recommends "/".
+        This affects how mailboxes appear to mail clients and sieve scripts.
+        For instance when using "." then in a sieve script "example.com" would refer to the mailbox "com" in the parent mailbox "example".
+        This does not determine the way your mails are stored on disk.
+        See https://wiki.dovecot.org/Namespaces for details.
+      '';
+    };
+
+    mailboxes = mkOption {
+      description = ''
+        The mailboxes for dovecot.
+        Depending on the mail client used it might be necessary to change some mailbox's name.
+      '';
+      default = [
+        {
+          name = "Trash";
+          auto = "no";
+          specialUse = "Trash";
+        }
+
+        {
+          name = "Junk";
+          auto = "subscribe";
+          specialUse = "Junk";
+        }
+
+        {
+          name = "Drafts";
+          auto = "subscribe";
+          specialUse = "Drafts";
+        }
+
+        {
+          name = "Sent";
+          auto = "subscribe";
+          specialUse = "Sent";
+        }
+      ];
+    };
+
     certificateScheme = mkOption {
       type = types.enum [ 1 2 3 ];
       default = 2;


### PR DESCRIPTION
- Factored mailbox config into its own option.
- Added hierarchy separator option.

I made the defaults default to what we have at the moment.
These things are necessary for two reasons: Converting a mailbox using doveadm sync requires the hierarchy separator to be set. Also if people want to bring their existing sieve scripts they will be happy if they can change that separator.
And the mailboxes are because Apple Mail.app is being special (unfortunately it is not alone with that).