### PR TITLE
mail-server/users.nix: don't expand variables in sieve script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ script:
 cache:
   directories:
       - /nix/store
+  timeout: 600

--- a/mail-server/users.nix
+++ b/mail-server/users.nix
@@ -50,7 +50,7 @@ let
           chown "${name}:${vmailGroupName}" "/var/sieve/${name}"
           chmod 770 "/var/sieve/${name}"
         fi
-        cat << EOF > "/var/sieve/${name}/default.sieve"
+        cat << 'EOF' > "/var/sieve/${name}/default.sieve"
         ${sieveScript}
         EOF
         chown "${name}:${vmailGroupName}" "/var/sieve/${name}/default.sieve"


### PR DESCRIPTION
With this change the sieve script

```
require ["fileinto", "mailbox"];

if address :is "from" "notifications@github.com" {
  fileinto :create "GitHub";
  stop;
}

# This must be the last rule, it will check if list-id is set, and
# file the message into the Lists folder for further investigation
elsif header :matches "list-id" "<?*>" {
  fileinto :create "Lists";
  stop;
}

# Test: ''${1}
# Test: ${builtins.toString 1234};
```
...gets interpreted like this:

```
$ cat /var/sieve/ruben@maher.fyi/default.sieve                                                                                                                                                    
require ["fileinto", "mailbox"];

if address :is "from" "notifications@github.com" {
  fileinto :create "GitHub";
  stop;
}

# This must be the last rule, it will check if list-id is set, and
# file the message into the Lists folder for further investigation
elsif header :matches "list-id" "<?*>" {
  fileinto :create "Lists";
  stop;
}

# Test: ${1}
# Test: 1234;
```

Fixes #71 