### PR TITLE
dovecot: read dovecot version into nix variable

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -325,16 +325,6 @@ in
       '';
     };
 
-    dovecot23 = mkOption {
-      type = types.bool;
-      default = false;
-      description =
-        ''
-        Activate this if you use Dovecot 2.3, so SSL works.
-        TODO: Remove this!
-        '';
-    };
-
     dhParamBitLength = mkOption {
       type = types.int;
       default = 2048;

--- a/mail-server/dovecot-version.nix
+++ b/mail-server/dovecot-version.nix
@@ -1,0 +1,12 @@
+{ dovecot, gawk, gnused, jq, runCommand }:
+
+runCommand "dovecot-version" {
+  buildInputs = [dovecot gnused jq];
+} ''
+  jq -n  \
+    --arg dovecot_version "$(dovecot --version |
+        sed 's/\([0-9.]*\).*/\1/' |
+        awk -F '.' '{ print $1"."$2"."$3 }')" \
+    '[$dovecot_version | split("."), ["major", "minor", "patch"]]
+       | transpose | map( { (.[1]): .[0] | tonumber }) | add' > $out
+''

--- a/mail-server/dovecot.nix
+++ b/mail-server/dovecot.nix
@@ -24,6 +24,8 @@ let
   # maildir in format "/${domain}/${user}"
   dovecot_maildir = "maildir:${cfg.mailDirectory}/%d/%n";
 
+  dovecotVersion = builtins.fromJSON
+    (builtins.readFile (pkgs.callPackage ./dovecot-version.nix {}));
 in
 {
   config = with cfg; lib.mkIf enable {
@@ -61,7 +63,9 @@ in
 
         mail_access_groups = ${vmailGroupName}
         ssl = required
-        ${lib.optionalString dovecot23 "ssl_dh = <${certificateDirectory}/dh.pem"}
+        ${lib.optionalString (dovecotVersion.major == 2 && dovecotVersion.minor >= 3) ''
+          ssl_dh = <${certificateDirectory}/dh.pem
+        ''}
 
         service lmtp {
           unix_listener /var/lib/postfix/queue/private/dovecot-lmtp {

--- a/mail-server/systemd.nix
+++ b/mail-server/systemd.nix
@@ -91,7 +91,12 @@ in
 
         ${create_certificate}
 
-        ${lib.optionalString cfg.dovecot23 "${createDhParameterFile}"}
+        ${let
+           dovecotVersion = builtins.fromJSON
+             (builtins.readFile (pkgs.callPackage ./dovecot-version.nix {}));
+          in lib.optionalString
+            (dovecotVersion.major == 2 && dovecotVersion.minor >= 3)
+            createDhParameterFile}
       '';
     };
 

--- a/tests/extern.nix
+++ b/tests/extern.nix
@@ -28,7 +28,6 @@ import <nixpkgs/nixos/tests/make-test.nix> {
               fqdn = "mail.example.com";
               domains = [ "example.com" "example2.com" ];
               dhParamBitLength = 512;
-              dovecot23 = true;
 
               loginAccounts = {
                   "user1@example.com" = {

--- a/tests/intern.nix
+++ b/tests/intern.nix
@@ -28,7 +28,6 @@ import <nixpkgs/nixos/tests/make-test.nix> {
           fqdn = "mail.example.com";
           domains = [ "example.com" ];
           dhParamBitLength = 512;
-          dovecot23 = true;
 
           loginAccounts = {
               "user1@example.com" = {


### PR DESCRIPTION
This adds a file `dovecot-version.nix` which is a derivation that produces a JSON blob like this:

```
❯ nix-build --expr 'with import <nixpkgs> {}; callPackage ./mail-server/dovecot-version.nix {}' && cat result
/nix/store/8srvh6d7d7c4n9jj83jz3fpdn0na4986-dovecot-version
{
  "major": 2,
  "minor": 3,
  "patch": 0
}
```

It can be used like this to check the current `dovecot` version:
```
nix-repl> builtins.fromJSON (builtins.readFile (pkgs.callPackage ./dovecot-version.nix {}))
{ major = 2; minor = 2; patch = 33; }
```
