### PR TITLE
ci: use current stable nixos-17.09 channel for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: nix
+env:
+  NIX_PATH="nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-17.09.tar.gz"
+
 script:
     - nix-build tests/intern.nix
     - nix-build tests/extern.nix


### PR DESCRIPTION
I'm submitting this for discussion but I'm not 100% sure that this is desirable.  I mean, it's definitely good to test against the stable channel but now that I think about it maybe it would be better to test against both stable and unstable?  That would not be hard to do, it would mean changing the Travis config to look like this:

```yaml
language: nix

script:
    - NIX_PATH="nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-17.09.tar.gz" nix-build tests/intern.nix
    - NIX_PATH="nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-17.09.tar.gz" nix-build tests/extern.nix
    - NIX_PATH="nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-unstable.tar.gz" nix-build tests/intern.nix
    - NIX_PATH="nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-unstable.tar.gz" nix-build tests/extern.nix

cache:
  directories:
- /nix/store
```

@r-raymond what do you think?