### PR TITLE
Don't include identity twice in vaccounts

### DIFF
--- a/mail-server/postfix.nix
+++ b/mail-server/postfix.nix
@@ -53,12 +53,6 @@ let
   # all_valiases_postfix :: [ String ]
   all_valiases_postfix = valiases_postfix ++ extra_valiases_postfix;
 
-  # accountToIdentity :: User -> String
-  accountToIdentity = account: "${account.name} ${account.name}";
-
-  # vaccounts_identity :: [ String ]
-  vaccounts_identity = map accountToIdentity (lib.attrValues cfg.loginAccounts);
-
   # valiases_file :: Path
   valiases_file = builtins.toFile "valias"
                       (lib.concatStringsSep "\n" (all_valiases_postfix ++
@@ -71,10 +65,9 @@ let
   # see
   # https://blog.grimneko.de/2011/12/24/a-bunch-of-tips-for-improving-your-postfix-setup/
   # for details on how this file looks. By using the same file as valiases,
-  # every alias is owned (uniquely) by its user. We have to add the users own
-  # address though
-  vaccounts_file = builtins.toFile "vaccounts" (lib.concatStringsSep "\n"
-  (vaccounts_identity ++ all_valiases_postfix));
+  # every alias is owned (uniquely) by its user. 
+  # The user's own address is already in all_valiases_postfix.
+  vaccounts_file = builtins.toFile "vaccounts" (lib.concatStringsSep "\n" all_valiases_postfix);
 
   submissionHeaderCleanupRules = pkgs.writeText "submission_header_cleanup_rules" ''
      # Removes sensitive headers from mails handed in via the submission port.

--- a/tests/extern.nix
+++ b/tests/extern.nix
@@ -249,5 +249,12 @@ import <nixpkgs/nixos/tests/make-test.nix> {
 
       };
 
+      subtest "no warnings or errors", sub {
+          $server->fail("journalctl -u postfix | grep -i error");
+          $server->fail("journalctl -u postfix | grep -i warning");
+          $server->fail("journalctl -u dovecot2 | grep -i error");
+          $server->fail("journalctl -u dovecot2 | grep -i warning");
+      };
+
     '';
 }


### PR DESCRIPTION
fixes #94 

I wasn't able to test the changes to `extern.nix` because of #95.