### PR TITLE
Avoid accepting mail to xyz@localhost from remote systems

### DIFF
--- a/mail-server/postfix.nix
+++ b/mail-server/postfix.nix
@@ -104,7 +104,7 @@ in
       extraConfig =
       ''
         # Extra Config
-        mydestination = localhost
+        mydestination =
 
         smtpd_banner = ${fqdn} ESMTP NO UCE
         disable_vrfy_command = yes


### PR DESCRIPTION
This prevents accepting emails addressed to xyz@localhost and thus avoids detecting valid account names from remote systems.
This does not affect email that is sent e.g. through the sendmail command, but the target addresses (or the two localhost and $myhostname domain) should be aliased to other users, or they will bounce and the bounce deleted, as it's not deliverable.
