### PR TITLE
Support for multiple extraVirtualAliases

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -135,19 +135,30 @@ in
     };
 
     extraVirtualAliases = mkOption {
-      type = types.attrsOf (types.enum (builtins.attrNames cfg.loginAccounts));
+      type = types.loaOf (mkOptionType {
+        name = "Login Account";
+        check = (ele:
+          let accounts = builtins.attrNames cfg.loginAccounts;
+          in if (builtins.isList ele)
+            then (builtins.all (x: builtins.elem x accounts) ele) && (builtins.length ele > 0)
+            else (builtins.elem ele accounts));
+      });
       example = {
         "info@example.com" = "user1@example.com";
         "postmaster@example.com" = "user1@example.com";
         "abuse@example.com" = "user1@example.com";
+        "multi@example.com" = [ "user1@example.com" "user2@example.com" ];
       };
       description = ''
-        Virtual Aliases. A virtual alias `"info@example2.com" = "user1@example.com"` means that
-        all mail to `info@example2.com` is forwarded to `user1@example.com`. Note
+        Virtual Aliases. A virtual alias `"info@example.com" = "user1@example.com"` means that
+        all mail to `info@example.com` is forwarded to `user1@example.com`. Note
         that it is expected that `postmaster@example.com` and `abuse@example.com` is
         forwarded to some valid email address. (Alternatively you can create login
         accounts for `postmaster` and (or) `abuse`). Furthermore, it also allows
-        the user `user1@example.com` to send emails as `info@example2.com`.
+        the user `user1@example.com` to send emails as `info@example.com`.
+        It's also possible to create an alias for multiple accounts. In this
+        example all mails for `multi@example.com` will be forwarded to both
+        `user1@example.com` and `user2@example.com`.
       '';
       default = {};
     };
@@ -160,7 +171,7 @@ in
         "abuse@example.com" = "user1@example.com";
       };
       description = ''
-        Alias for extraVirtualAliases. Deprecated.
+        Alias for extraVirtualAliases, but only for single aliases! Deprecated.
       '';
       default = {};
     };

--- a/mail-server/postfix.nix
+++ b/mail-server/postfix.nix
@@ -47,7 +47,10 @@ let
     (map
     (from:
       let to = cfg.extraVirtualAliases.${from};
-      in "${from} ${to}")
+          aliasList = (l: let aliasStr = builtins.foldl' (x: y: x + y + ", ") "" l;
+                          in builtins.substring 0 (builtins.stringLength aliasStr - 2) aliasStr);
+      in if (builtins.isList to) then "${from} " + (aliasList to)
+                                 else "${from} ${to}")
     (builtins.attrNames cfg.extraVirtualAliases));
 
   # all_valiases_postfix :: [ String ]

--- a/tests/extern.nix
+++ b/tests/extern.nix
@@ -49,6 +49,11 @@ import <nixpkgs/nixos/tests/make-test.nix> {
                   };
               };
 
+              extraVirtualAliases = {
+                "single-alias@example.com" = "user1@example.com";
+                "multi-alias@example.com" = [ "user1@example.com" "user2@example.com" ];
+              };
+
               enableImap = true;
             };
         };
@@ -113,6 +118,13 @@ import <nixpkgs/nixos/tests/make-test.nix> {
               from           postmaster@example.com
               user           user1@example.com
               password       user1
+
+              account        test5
+              host           ${serverIP}
+              port           587
+              from           single-alias@example.com
+              user           user1@example.com
+              password       user1
             '';
           };
           "root/email1".text = ''
@@ -153,6 +165,34 @@ import <nixpkgs/nixos/tests/make-test.nix> {
 
             I think I may have misconfigured the mail server
             XOXO Postmaster
+          '';
+          "root/email4".text = ''
+            From: Single Alias <single-alias@example.com>
+            To: User1 <user1@example.com>
+            Cc:
+            Bcc:
+            Subject: This is a test Email from single-alias\@example.com to user1
+            Reply-To:
+
+            Hello User1,
+
+            how are you doing today?
+
+            XOXO User1 aka Single Alias
+          '';
+          "root/email5".text = ''
+            From: User2 <user2@example.com>
+            To: Multi Alias <multi-alias@example.com>
+            Cc:
+            Bcc:
+            Subject: This is a test Email from user2\@example.com to multi-alias
+            Reply-To:
+
+            Hello Multi Alias,
+
+            how are we doing today?
+
+            XOXO User1
           '';
         };
       };
@@ -236,6 +276,22 @@ import <nixpkgs/nixos/tests/make-test.nix> {
           # fetchmail returns EXIT_CODE 1 when no new mail
           # if this succeeds, it means that user1 recieved the mail that was intended for chuck.
           $client->fail("fetchmail -v");
+      };
+
+      subtest "extraVirtualAliases", sub {
+          $client->execute("rm ~/mail/*");
+          # send email from single-alias to user1
+          $client->succeed("msmtp -a test5 --tls=on --tls-certcheck=off --auth=on user1\@example.com < /etc/root/email4 >&2");
+          $server->waitUntilFails('[ "$(postqueue -p)" != "Mail queue is empty" ]');
+          # fetchmail returns EXIT_CODE 0 when it retrieves mail
+          $client->succeed("fetchmail -v");
+
+          $client->execute("rm ~/mail/*");
+          # send email from user1 to multi-alias (user{1,2}@example.com)
+          $client->succeed("msmtp -a test --tls=on --tls-certcheck=off --auth=on multi-alias\@example.com < /etc/root/email5 >&2");
+          $server->waitUntilFails('[ "$(postqueue -p)" != "Mail queue is empty" ]');
+          # fetchmail returns EXIT_CODE 0 when it retrieves mail
+          $client->succeed("fetchmail -v");
       };
 
       subtest "quota", sub {


### PR DESCRIPTION
Should fix #104 by introducing

```
extraVirtualAliases = {
  "single-alias@domain.foobar" = "user1@domain.foobar";
  "multi-alias@domain.foobar" = [
    "user1@domain.foobar" "user2@domain.foobar" ];
};
```