### PR TITLE
Fog user's hostname in the Message-ID

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -433,6 +433,16 @@ in
       '';
     };
 
+    rewriteMessageId = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Rewrites the Message-ID's hostname-part of outgoing emails to the FQDN.
+        Please be aware that this may cause problems with some mail clients
+        relying on the original Message-ID.
+      '';
+    };
+
     monitoring = {
       enable = mkEnableOption "monitoring via monit";
 

--- a/mail-server/postfix.nix
+++ b/mail-server/postfix.nix
@@ -66,7 +66,7 @@ let
   # The user's own address is already in all_valiases_postfix.
   vaccounts_file = builtins.toFile "vaccounts" (lib.concatStringsSep "\n" all_valiases_postfix);
 
-  submissionHeaderCleanupRules = pkgs.writeText "submission_header_cleanup_rules" ''
+  submissionHeaderCleanupRules = pkgs.writeText "submission_header_cleanup_rules" (''
      # Removes sensitive headers from mails handed in via the submission port.
      # See https://thomas-leister.de/mailserver-debian-stretch/
      # Uses "pcre" style regex.
@@ -76,7 +76,13 @@ let
      /^X-Mailer:/            IGNORE
      /^User-Agent:/          IGNORE
      /^X-Enigmail:/          IGNORE
-  '';
+  '' + lib.optionalString cfg.rewriteMessageId ''
+
+     # Replaces the user submitted hostname with the server's FQDN to hide the
+     # user's host or network.
+
+     /^Message-ID:\s+<(.*?)@.*?>/ REPLACE Message-ID: <$1@${cfg.fqdn}>
+  '');
 in
 {
   config = with cfg; lib.mkIf enable {


### PR DESCRIPTION
The `Message-ID`-field of an outgoing email contains the user's hostname, set by the email client. This hostname can reveal both the hostname (obvious) and furthermore the network's domain name. For example this field says if I am currently at home, at work, at the university and so on.

This PR intends to replaces the hostname part with the server's FQDN.