### PR TITLE
Added option for automatic reboot after a kernel upgrade.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -621,6 +621,27 @@ in
 
     };
 
+    rebootAfterKernelUpgrade = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        example = true;
+        description = ''
+          Whether to enable automatic reboot after kernel upgrades.
+          This is to be used in conjunction with system.autoUpgrade.enable = true"
+        '';
+      };
+      method = mkOption {
+        type = types.enum [ "reboot" "systemctl kexec" ];
+        default = "reboot";
+        description = ''
+          Whether to issue a full "reboot" or just a "systemctl kexec"-only reboot.
+          It is recommended to use the default value because the quicker kexec reboot has a number of problems.
+          Also if your server is running in a virtual machine the regular reboot will already be very quick.
+        '';
+      };
+    };
+
     backup = {
       enable = mkEnableOption "backup via rsnapshot";
 
@@ -695,5 +716,6 @@ in
     ./mail-server/rmilter.nix
     ./mail-server/nginx.nix
     ./mail-server/kresd.nix
+    ./mail-server/post-upgrade-check.nix
   ];
 }

--- a/mail-server/post-upgrade-check.nix
+++ b/mail-server/post-upgrade-check.nix
@@ -1,0 +1,46 @@
+#  nixos-mailserver: a simple mail server
+#  Copyright (C) 2016-2018  Robin Raymond
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program. If not, see <http://www.gnu.org/licenses/>
+
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.mailserver;
+in
+{
+  config = mkIf cfg.rebootAfterKernelUpgrade.enable {
+    systemd.services.nixos-upgrade.serviceConfig.ExecStartPost = pkgs.writeScript "post-upgrade-check" ''
+      #!${pkgs.stdenv.shell}
+      
+      # Checks whether the "current" kernel is different from the booted kernel
+      # and then triggers a reboot so that the "current" kernel will be the booted one.
+      # This is just an educated guess. If the links do not differ the kernels might still be different, according to spacefrogg in #nixos.
+      
+      current=$(readlink -f /run/current-system/kernel)
+      booted=$(readlink -f /run/booted-system/kernel)
+      
+      if [ "$current" == "$booted" ]; then
+        echo "kernel version seems unchanged, skipping reboot" | systemd-cat --priority 4 --identifier "post-upgrade-check";
+      else
+        echo "kernel path changed, possibly a new version" | systemd-cat --priority 2 --identifier "post-upgrade-check"
+        echo "$booted" | systemd-cat --priority 2 --identifier "post-upgrade-kernel-check"
+        echo "$current" | systemd-cat --priority 2 --identifier "post-upgrade-kernel-check"
+        ${cfg.rebootAfterKernelUpgrade.method}
+      fi
+    '';
+  };
+}

--- a/mail-server/rsnapshot.nix
+++ b/mail-server/rsnapshot.nix
@@ -1,5 +1,5 @@
 #  nixos-mailserver: a simple mail server
-#  Copyright (C) 2016-2017  Robin Raymond
+#  Copyright (C) 2016-2018  Robin Raymond
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
When [meltdown and spectre](https://meltdownattack.com) happened I wrote a little script to automatically restart my mail server after a (then almost daily) kernel upgrade. This is a cleaned up version. I might put this on nixpkgs eventually but for now I wanted to have it out there at least for NMS so others can sleep better at night knowing their server will apply a kernel upgrade by itself.