### PR TITLE
dkim: set header canonicalization to relaxed

### DIFF
--- a/mail-server/rmilter.nix
+++ b/mail-server/rmilter.nix
@@ -40,6 +40,7 @@ let
               };
               sign_alg = sha256;
               auth_only = yes;
+              header_canon = relaxed;
             }
          ''
          else "";


### PR DESCRIPTION
Instead of simple canonicalization which is the default one.

Fixes #120