### PR TITLE
postfix: also create the dh.pem if it is empty

### DIFF
--- a/mail-server/systemd.nix
+++ b/mail-server/systemd.nix
@@ -41,7 +41,7 @@ let
   createDhParameterFile =
     ''
       # Create a dh parameter file
-      if [ ! -f "${cfg.certificateDirectory}/dh.pem" ]
+      if [ ! -s "${cfg.certificateDirectory}/dh.pem" ]
       then
           mkdir -p "${cfg.certificateDirectory}"
           ${pkgs.openssl}/bin/openssl \


### PR DESCRIPTION
The dh.pem file is currently created by the postfix prestart
script. If the entropy of the system is to low, the postfix prestart
can timeout. In this case, an empty file is created.
If the user restarts the postfix service, the dh.pem is not created
because the file already exists (but is empty).
When a ssl is established with dovecot, it fails with this message:
imap-login: `Error:Failed to initialize SSL server context: Couldn't parse DH parameters:
error:0906D06C:PEM routines:PEM_read_bio:no start line: Expecting: DH
PARAMETERS`

With this patch, the postfix service creates the dh.pem if the dh.pem
doesn't exist or if it is empty. It doesn't fix the entropy or
timeout issue but at least, the user knows something is failing:/