### PR TITLE
fix conditions for enabling services

### DIFF
--- a/mail-server/borgbackup.nix
+++ b/mail-server/borgbackup.nix
@@ -19,7 +19,7 @@
 let
   cfg = config.mailserver.borgbackup;
 
-  methodFragment = lib.optional (cfg.compression.method != null) cfg.compression.method;  
+  methodFragment = lib.optional (cfg.compression.method != null) cfg.compression.method;
   autoFragment =
     if cfg.compression.auto && cfg.compression.method == null
     then throw "compression.method must be set when using auto."
@@ -56,7 +56,7 @@ let
     ${cmdPostexec}
   '';
 in {
-  config = lib.mkIf config.mailserver.borgbackup.enable {
+  config = lib.mkIf (config.mailserver.enable && cfg.enable) {
     environment.systemPackages = with pkgs; [
       borgbackup
     ];

--- a/mail-server/clamav.nix
+++ b/mail-server/clamav.nix
@@ -20,7 +20,7 @@ let
   cfg = config.mailserver;
 in
 {
-  config = lib.mkIf cfg.virusScanning {
+  config = lib.mkIf (cfg.enable && cfg.virusScanning) {
     services.clamav.daemon.enable = true;
     services.clamav.updater.enable = true;
   };

--- a/mail-server/kresd.nix
+++ b/mail-server/kresd.nix
@@ -20,7 +20,7 @@ let
   cfg = config.mailserver;
 in
 {
-  config = lib.mkIf cfg.localDnsResolver {
+  config = lib.mkIf (cfg.enable && cfg.localDnsResolver) {
     services.kresd.enable = true;
     networking.nameservers = [ "127.0.0.1" ];
   };

--- a/mail-server/monit.nix
+++ b/mail-server/monit.nix
@@ -20,7 +20,7 @@ let
   cfg = config.mailserver;
 in
 {
-  config = lib.mkIf cfg.monitoring.enable {
+  config = lib.mkIf (cfg.enable && cfg.monitoring.enable) {
     services.monit = {
       enable = true;
       config = ''

--- a/mail-server/nginx.nix
+++ b/mail-server/nginx.nix
@@ -24,7 +24,7 @@ let
   acmeRoot = "/var/lib/acme/acme-challenge";
 in
 {
-  config = lib.mkIf (cfg.certificateScheme == 3) {
+  config = lib.mkIf (cfg.enable && cfg.certificateScheme == 3) {
     services.nginx = {
       enable = true;
       virtualHosts."${cfg.fqdn}" = {

--- a/mail-server/post-upgrade-check.nix
+++ b/mail-server/post-upgrade-check.nix
@@ -22,17 +22,17 @@ let
   cfg = config.mailserver;
 in
 {
-  config = mkIf cfg.rebootAfterKernelUpgrade.enable {
+  config = mkIf (cfg.enable && cfg.rebootAfterKernelUpgrade.enable) {
     systemd.services.nixos-upgrade.serviceConfig.ExecStartPost = pkgs.writeScript "post-upgrade-check" ''
       #!${pkgs.stdenv.shell}
-      
+
       # Checks whether the "current" kernel is different from the booted kernel
       # and then triggers a reboot so that the "current" kernel will be the booted one.
       # This is just an educated guess. If the links do not differ the kernels might still be different, according to spacefrogg in #nixos.
-      
+
       current=$(readlink -f /run/current-system/kernel)
       booted=$(readlink -f /run/booted-system/kernel)
-      
+
       if [ "$current" == "$booted" ]; then
         echo "kernel version seems unchanged, skipping reboot" | systemd-cat --priority 4 --identifier "post-upgrade-check";
       else

--- a/mail-server/rsnapshot.nix
+++ b/mail-server/rsnapshot.nix
@@ -39,7 +39,7 @@ let
   '';
   postexecString = optionalString postexecDefined "cmd_postexec	${postexecWrapped}";
 in {
-  config = mkIf cfg.backup.enable {
+  config = mkIf (cfg.enable && cfg.backup.enable) {
     services.rsnapshot = {
       enable = true;
       cronIntervals = cfg.backup.cronIntervals;


### PR DESCRIPTION
Without this fix, kresd and others would get enabled even though the
main mailserver option is disabled.

This effectively broke DNS on my laptop and pc, because I'm including the nixos-mailserver module for every machine -> kresd got enabled automatically without me wanting to, which ultimately broke.