### PR TITLE
Disabled scanning of incoming mails for phishing attempts

### DIFF
--- a/mail-server/clamav.nix
+++ b/mail-server/clamav.nix
@@ -23,6 +23,10 @@ in
   config = lib.mkIf cfg.virusScanning {
     services.clamav.daemon.enable = true;
     services.clamav.updater.enable = true;
+
+    services.clamav.daemon.extraConfig = ''
+      PhishingScanURLs no
+    '';
   };
 }
 


### PR DESCRIPTION
I have had one legit email by PayPal being rejected and bounced because ClamAV considered this one to be a phishing attempt. I expect rspamd to be better suited at detecting this than the anti virus software so this PR disables this for ClamAV. This gives rspamd the chance to look at the mail and decide what to do with it.

Now unfortunately I don't have an easy way to test if this actually works. According to the man page and a number of different sites this is the option to set to no when you get  false positives for `Heuristics.Phishing.Email.SpoofedDomain` which is what happened to me. So I'm… positive… that this might work